### PR TITLE
Added Minecraft session server, removed login server

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,7 +27,7 @@ get '/status.json' do
     result[:results][:minecraft] = get_code("http://minecraft.net")
     result[:results][:wiki] = get_code("http://minecraftwiki.net")
     result[:results][:forum] = get_code("http://minecraftfourm.net")
-    result[:results][:login] = get_code("https://login.minecraft.net")
+    result[:results][:session] = get_code("http://session.minecraft.net")
     result[:check_time] = @now.to_s
     result[:next_check] = CACHE.get('time') + 300
     CACHE.set('json', result)
@@ -85,12 +85,12 @@ def check(force)
     @forums = get_status("http://minecraftforum.net")    
     CACHE.set('forums', @forums)
 
-    @login = get_status("https://login.minecraft.net")
-    CACHE.set('login', @login)
+    @session = get_status("http://session.minecraft.net")
+    CACHE.set('session', @session)
   else
     @main = CACHE.get('main')
     @wiki = CACHE.get('wiki')
     @forums = CACHE.get('forums')
-    @login = CACHE.get('login')
+    @session = CACHE.get('session')
   end
 end

--- a/views/index.haml
+++ b/views/index.haml
@@ -1,6 +1,9 @@
 %h1.site
   = "minecraft.net #{@main.to_s}"
 
+%hl.site
+  = "session.minecraft.net #{@session.to_s}"
+
 %h1.site
   = "minecraftwiki.net #{@wiki.to_s}"
 


### PR DESCRIPTION
The login service is now on Amazon EC2 instances, the sessions service isn't - which goes down frequently. It would be nice to have this, as many players get confused as to why the site says Minecraft is up (which it is) yet are unable to play.
